### PR TITLE
Full cycle of upload/download of an artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,20 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
+      - name: Build package
+        run: python -m build
+
       - name: Upload site artifact
         uses: actions/upload-artifact@v4
         with:
           name: site
           path: site
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
 
   deploy-docs:
     needs: build-test-docs
@@ -85,35 +94,35 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
         with:
-          python-version: '3.11'
-      - name: Install build tools
-        run: pip install build twine
-      - name: Build package
-        run: python -m build
+          name: dist
+          path: dist
+
       - name: Publish to TestPyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        run: twine upload --repository testpypi dist/*
+        run: |
+          pip install twine
+          twine upload --repository testpypi dist/*
 
   publish-pypi:
     needs: build-test-docs
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
         with:
-          python-version: '3.11'
-      - name: Install build tools
-        run: pip install build twine
-      - name: Build package
-        run: python -m build
+          name: dist
+          path: dist
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/*
+        run: |
+          pip install twine
+          twine upload dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,32 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  release:
+    types: [published]
 
 jobs:
   build-test-docs:
     runs-on: ubuntu-latest
-    
     permissions:
       contents: write
-      
+
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          
-          persist-credentials: false 
+          fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |
@@ -32,10 +41,16 @@ jobs:
         run: flake8 .
 
       - name: Run tests
-        run: pytest --cov=.
+        run: pytest --cov=. --cov-report=xml
 
       - name: Build docs
         run: mkdocs build --strict
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: site
 
   deploy-docs:
     needs: build-test-docs
@@ -43,28 +58,62 @@ jobs:
     if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-  
-      - uses: actions/setup-python@v5
+
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
         with:
-          python-version: '3.11'
-  
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
-  
+          name: site
+          path: site
+
       - name: Deploy to GitHub Pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/maxshushanikov/filestructor.git
-          
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           mkdocs gh-deploy --force --no-history --site-dir site
+
+  publish-testpypi:
+    needs: build-test-docs
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tools
+        run: pip install build twine
+      - name: Build package
+        run: python -m build
+      - name: Publish to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: twine upload --repository testpypi dist/*
+
+  publish-pypi:
+    needs: build-test-docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tools
+        run: pip install build twine
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*


### PR DESCRIPTION
Fixes #20 
In build-test-docs:

The Upload site artifact step has been added after building the documentation (mkdocs build).

In deploy-docs:

The Download site artifact step has been added before deployment to use a pre-built site.

Dependency installation and rebuilding have been removed, saving time.