### PR TITLE
Fixes #20 deletes license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = []
 keywords = ["project-structure", "scaffolding", "inspection", "generator"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Environment :: Console",
   "Topic :: Software Development :: Code Generators"


### PR DESCRIPTION
license = "MIT" + license-files = ["LICENSE"] — modern format.

Removed conflicting license classifier.

site/ and tests/ are explicitly excluded.