### PR TITLE
Using peaceiris/actions-gh-pages to avoid the need to install mkdocs …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,13 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - name: Upload site artifact  
+      - name: Upload site artifact
         uses: actions/upload-artifact@v4
         with:
           name: site
           path: site
 
-      - name: Remove site directory before build 
+      - name: Remove site directory before build
         run: rm -rf site
 
       - name: Build package
@@ -73,9 +73,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
 
       - name: Download site artifact
         uses: actions/download-artifact@v4
@@ -84,13 +81,10 @@ jobs:
           path: site
 
       - name: Deploy to GitHub Pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          mkdocs gh-deploy --force --no-history --site-dir site
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
 
   publish-testpypi:
     needs: build-test-docs
@@ -111,6 +105,14 @@ jobs:
           pip install twine
           twine check dist/*
           twine upload --repository testpypi dist/*
+
+      - name: Verify install from TestPyPI
+        run: |
+          python -m venv venv-test
+          source venv-test/bin/activate
+          pip install --index-url https://test.pypi.org/simple/ \
+                      --extra-index-url https://pypi.org/simple structor
+          python -c "import app; print('✅ Package imported successfully')"
 
   publish-pypi:
     needs: build-test-docs


### PR DESCRIPTION
…in the deployment job

The site (site/) and package (dist/) are built once.

site/ is first uploaded as an artifact, then removed before building the package to prevent it from being distributed.

Documentation is deployed via peaceiris/actions-gh-pages.

The package is published on TestPyPI when pushed to master, and the installation is verified from TestPyPI.

The package is published on PyPI when released (tags).

A twine check is performed before publishing.