### PR TITLE
Removes license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Project structure generator with file content inspection"
 authors = [{ name = "Maxim Shushanikov", email = "max.shushanikov@gmail.com" }]
 readme = "README.md"
 license = "MIT"
-license-files = ["LICENSE"]
 requires-python = ">=3.8"
 dependencies = []
 keywords = ["project-structure", "scaffolding", "inspection", "generator"]


### PR DESCRIPTION
Removes license-files to avoid the error "unrecognized or malformed field 'license-file'"